### PR TITLE
fix: :bug: Narrowed injection scope

### DIFF
--- a/syntaxes/alpine-intellisense.injection.json
+++ b/syntaxes/alpine-intellisense.injection.json
@@ -1,6 +1,6 @@
 {
   "scopeName": "alpine-intellisense.injection",
-  "injectionSelector": ["L:text.html"],
+  "injectionSelector": ["L:meta.tag -meta.attribute"],
   "patterns": [
     {
       "include": "#mark-as-js"


### PR DESCRIPTION
Narrowed injection scope to remove bugs associated with syntax highlighting in improper places like within an attribute our between html tags. Fixes #1.